### PR TITLE
cleanup

### DIFF
--- a/src/operators/relational/logical.rs
+++ b/src/operators/relational/logical.rs
@@ -401,7 +401,7 @@ impl LogicalJoin {
             0 => Some(self.left.mexpr()),
             1 => Some(self.right.mexpr()),
             2 => match &self.condition {
-                JoinCondition::Using(_) => unreachable!(),
+                JoinCondition::Using(_) => None,
                 JoinCondition::On(on) => Some((&on.expr).mexpr()),
             },
             _ => None,

--- a/src/operators/relational/physical.rs
+++ b/src/operators/relational/physical.rs
@@ -354,7 +354,7 @@ impl HashJoin {
             0 => Some(self.left.mexpr()),
             1 => Some(self.right.mexpr()),
             2 => match &self.condition {
-                JoinCondition::Using(_) => unreachable!(),
+                JoinCondition::Using(_) => None,
                 JoinCondition::On(on) => Some(on.expr.mexpr()),
             },
             _ => None,

--- a/src/operators/scalar/exprs.rs
+++ b/src/operators/scalar/exprs.rs
@@ -34,6 +34,7 @@ where
 
 #[cfg(test)]
 mod test {
+    use crate::meta::ColumnId;
     use crate::operators::scalar::expr::{BinaryOp, NestedExpr};
     use crate::operators::scalar::exprs::collect_columns;
     use crate::operators::scalar::value::ScalarValue;
@@ -67,6 +68,7 @@ mod test {
 
         let expr = Expr::Scalar(ScalarValue::Int32(1));
         let columns = collect_columns(&expr);
-        assert_eq!(columns, vec![], "no columns");
+        let empty = Vec::<ColumnId>::new();
+        assert_eq!(columns, empty, "no columns");
     }
 }

--- a/src/rules/rewrite/mod.rs
+++ b/src/rules/rewrite/mod.rs
@@ -1,4 +1,51 @@
+use crate::memo::{MemoExpr, NewChildExprs};
+use crate::operators::relational::RelNode;
+use crate::operators::Operator;
+use std::collections::VecDeque;
+
 mod filter_push_down;
 mod remove_redundant_projections;
 #[cfg(test)]
 mod testing;
+
+/// Rewrites relational child expressions of the relational expression `expr` using the given function.
+pub fn rewrite_rel_inputs<T>(expr: &RelNode, mut rewrite: T) -> RelNode
+where
+    T: FnMut(&RelNode) -> RelNode,
+{
+    let children = expr
+        .mexpr()
+        .children()
+        .filter_map(|child_expr| {
+            if child_expr.expr().is_relational() {
+                let child_expr = RelNode::from(child_expr.clone());
+                let child_expr = (rewrite)(&child_expr);
+                Some(child_expr)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    with_new_rel_inputs(expr, children)
+}
+
+/// Creates a new relational expression from the given expression by replacing its child relational expressions.
+pub fn with_new_rel_inputs(expr: &RelNode, mut inputs: Vec<RelNode>) -> RelNode {
+    if inputs.is_empty() {
+        return expr.clone();
+    }
+
+    let mut new_children = VecDeque::new();
+    for child_expr in expr.mexpr().children() {
+        let child_expr = if child_expr.expr().is_relational() {
+            inputs.swap_remove(0).into_inner()
+        } else {
+            child_expr.clone()
+        };
+        new_children.push_back(child_expr);
+    }
+
+    let expr = Operator::expr_with_new_children(expr.mexpr().expr(), NewChildExprs::new(new_children));
+    RelNode::from(Operator::from(expr))
+}

--- a/src/rules/rewrite/remove_redundant_projections.rs
+++ b/src/rules/rewrite/remove_redundant_projections.rs
@@ -1,10 +1,9 @@
-use crate::memo::MemoExpr;
 use crate::operators::relational::join::JoinCondition;
 use crate::operators::relational::logical::{
     LogicalAggregate, LogicalExpr, LogicalGet, LogicalJoin, LogicalProjection,
 };
 use crate::operators::relational::RelNode;
-use crate::rules::rewrite::filter_push_down::new_inputs;
+use crate::rules::rewrite::rewrite_rel_inputs;
 
 /// A basic implementation of a redundant projection removal rule.
 ///
@@ -108,18 +107,7 @@ fn rewrite(expr: &RelNode) -> RelNode {
 }
 
 fn rewrite_inputs(expr: &RelNode) -> RelNode {
-    let mut children = vec![];
-
-    for i in 0..expr.mexpr().num_children() {
-        let child_expr = expr.mexpr().get_child(i).unwrap();
-        if child_expr.expr().is_relational() {
-            let child_expr = RelNode::from(child_expr.clone());
-            let child_expr = rewrite(&child_expr);
-            children.push(child_expr);
-        }
-    }
-
-    new_inputs(expr, children)
+    rewrite_rel_inputs(expr, rewrite)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
rewrites: extract common functions.
memo expr: add iterator over child expressions.
expr rewriter: add post rewrite method.