### PR TITLE
rules: cleanup.

### DIFF
--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -16,7 +16,7 @@ use crate::operators::relational::{RelExpr, RelNode};
 use crate::operators::scalar::expr_with_new_inputs;
 use crate::operators::{ExprMemo, ExprRef, Operator, OperatorExpr, OperatorMetadata, Properties};
 use crate::properties::physical::PhysicalProperties;
-use crate::rules::{RuleContext, RuleId, RuleMatch, RuleResult, RuleSet, RuleType};
+use crate::rules::{EvaluationResponse, RuleContext, RuleId, RuleMatch, RuleResult, RuleSet, RuleType};
 use crate::util::{BestExprContext, BestExprRef, ResultCallback};
 
 /// Cost-based optimizer.
@@ -617,7 +617,10 @@ where
 {
     let physical_expr = expr.expr().relational().physical();
     let required_properties = physical_expr.build_required_properties();
-    let (provides_property, retains_property) = rule_set
+    let EvaluationResponse {
+        provides_property,
+        retains_property,
+    } = rule_set
         .evaluate_properties(physical_expr, &ctx.required_properties)
         .expect("Invalid expr or required physical properties");
 

--- a/src/rules/testing.rs
+++ b/src/rules/testing.rs
@@ -18,7 +18,7 @@ use crate::operators::scalar::ScalarExpr;
 use crate::operators::{ExprMemo, Operator, OperatorExpr, OperatorMetadata, Properties, RelationalProperties};
 use crate::properties::logical::LogicalProperties;
 use crate::properties::physical::PhysicalProperties;
-use crate::rules::{Rule, RuleContext, RuleId, RuleIterator, RuleResult, RuleSet};
+use crate::rules::{EvaluationResponse, Rule, RuleContext, RuleId, RuleIterator, RuleResult, RuleSet};
 
 /// Expects that given expression does not match the given rule.
 ///
@@ -183,7 +183,7 @@ where
         &self,
         expr: &PhysicalExpr,
         required_properties: &PhysicalProperties,
-    ) -> Result<(bool, bool), OptimizerError> {
+    ) -> Result<EvaluationResponse, OptimizerError> {
         self.rule_set.evaluate_properties(expr, required_properties)
     }
 


### PR DESCRIPTION
evaluate_properties return struct instead of (bool, bool).