### PR TITLE
make cost f64. use type aliases for row count and selectivity statistics.

### DIFF
--- a/src/cost/mod.rs
+++ b/src/cost/mod.rs
@@ -6,13 +6,13 @@ use crate::statistics::Statistics;
 
 pub mod simple;
 
-//FIXME replace usize with f64
-//FIXME Wrap into struct to prevent overflows.
-pub type Cost = usize;
+/// The cost of a plan.
+//FIXME Wrap into struct to prevent overflows?
+pub type Cost = f64;
 
 /// Estimates a cost of a physical expression.
 pub trait CostEstimator {
-    /// Estimates the cost of the given physical expression.
+    /// Estimates the cost of the given physical expression excluding the cost of its inputs.
     fn estimate_cost(&self, expr: &PhysicalExpr, ctx: &CostEstimationContext, statistics: Option<&Statistics>) -> Cost;
 }
 
@@ -24,6 +24,8 @@ pub struct CostEstimationContext {
 
 impl CostEstimationContext {
     /// Returns statistics of the i-th child expression.
+    /// Because scalar expressions do not have independent statistics this method returns `None`
+    /// if the `i`-th expression is a scalar expression. See [Statistics].
     pub fn child_statistics(&self, i: usize) -> Option<&Statistics> {
         let best_expr = &self.inputs[i];
         match best_expr.props() {

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -364,7 +364,7 @@ where
         let expr = group.mexpr();
 
         if expr.children().len() == 0 {
-            let best_expr = BestExpr::new(expr.clone(), 0, vec![]);
+            let best_expr = BestExpr::new(expr.clone(), 0.0, vec![]);
             state.best_expr = Some(best_expr);
         } else {
             let task = get_optimize_scalar_inputs_task(&ctx, expr);
@@ -1121,7 +1121,7 @@ fn new_cost_estimation_ctx(
 ) -> Result<(CostEstimationContext, Cost), OptimizerError> {
     let capacity = inputs.inputs.len();
     let mut best_exprs = Vec::with_capacity(capacity);
-    let mut input_cost = 0;
+    let mut input_cost = 0.0;
 
     for ctx in inputs.inputs.iter() {
         let group_state = state.get_state(ctx)?;

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -7,28 +7,31 @@ use crate::properties::logical::LogicalProperties;
 
 pub mod simple;
 
-/// The number of rows returned by an operator in case when no statistics is available.
-pub const UNKNOWN_ROW_COUNT: f64 = 1000f64;
+/// The estimated number of rows returned by an operator.
+pub type RowCount = f64;
+
+/// The portion of rows that match a predicate. The valid range of selectivity is `[0.0; 1.0]`.
+pub type Selectivity = f64;
 
 /// Statistics associated with an operator.
+///
+/// * Statistics for most relational operators should be created from [RowCount] via `From` conversion.
+///
+/// * Statistics for `Restriction`/`Select`/`Filter` operators must be created by
+/// providing both [RowCount] and [Selectivity] and the former must already include the latter.
+/// For example: If `SELECT FROM a WHERE a1 > 10` produces 100 rows and
+/// selectivity of `a1 > 10` is `0.1` then `Statistics` object is going have
+/// `row_count` of `10` (`100*0.1`) and `selectivity` of `0.1`.
+///
 #[derive(Debug, Clone)]
 pub struct Statistics {
-    row_count: f64,
-    selectivity: f64,
-}
-
-impl Default for Statistics {
-    fn default() -> Self {
-        Self {
-            row_count: UNKNOWN_ROW_COUNT,
-            selectivity: Statistics::DEFAULT_SELECTIVITY,
-        }
-    }
+    row_count: RowCount,
+    selectivity: Selectivity,
 }
 
 impl Statistics {
     /// The default value of selectivity statistics.
-    pub const DEFAULT_SELECTIVITY: f64 = 1.0;
+    pub const DEFAULT_SELECTIVITY: Selectivity = 1.0;
 
     /// Creates new statistics with the given row count and selectivity.
     ///
@@ -64,12 +67,12 @@ impl Statistics {
     }
 
     /// The estimated number of rows returned by an operator.
-    pub fn row_count(&self) -> f64 {
+    pub fn row_count(&self) -> RowCount {
         self.row_count
     }
 
     /// The selectivity of a predicate.
-    pub fn selectivity(&self) -> f64 {
+    pub fn selectivity(&self) -> Selectivity {
         self.selectivity
     }
 }


### PR DESCRIPTION
use type aliases for row count and selectivity statistics.