### PR TITLE
Use argument error

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Cost-based query optimizer (WIP).
 - [x] CASE expression.
 - [x] LIKE/NOT LIKE
 - [x] Tuples.
-- [ ] Array access.
+- [x] Array access.
 - [x] Window functions.
 - [ ] User-defined aggregate functions.
 - TODO

--- a/src/operators/builder/mod.rs
+++ b/src/operators/builder/mod.rs
@@ -1110,7 +1110,7 @@ where
                 })
                 .collect();
 
-            OptimizerError::internal(format!(
+            OptimizerError::argument(format!(
                 "Unexpected column: {}. Input columns: {}, Outer columns: {}",
                 col_name,
                 DisplayColumns(scope.columns()),

--- a/src/operators/builder/scope.rs
+++ b/src/operators/builder/scope.rs
@@ -204,9 +204,9 @@ impl OperatorScope {
                     Ok(columns)
                 }
                 None if self.relations.find_relation_by_name(qualifier).is_some() => {
-                    Err(OptimizerError::internal(format!("Invalid reference to relation {}", qualifier)))
+                    Err(OptimizerError::argument(format!("Invalid reference to relation {}", qualifier)))
                 }
-                None => Err(OptimizerError::internal(format!("Unknown relation {}", qualifier))),
+                None => Err(OptimizerError::argument(format!("Unknown relation {}", qualifier))),
             }
         } else {
             Ok(self.relation.columns.to_vec())

--- a/src/operators/scalar/func.rs
+++ b/src/operators/scalar/func.rs
@@ -179,7 +179,7 @@ where
             FunctionReturnType::Expr(expr) => (expr)(arg_types),
         }
     } else {
-        Err(OptimizerError::internal(format!("No function {}({})", func, arg_types.iter().join(", "))))
+        Err(OptimizerError::argument(format!("No function {}({})", func, arg_types.iter().join(", "))))
     }
 }
 
@@ -277,7 +277,7 @@ mod test {
             .map_err(|e| format!("{}", e))
             .map(|r| format!("{}", r));
 
-        assert_eq!(result, Err(format!("Internal error: No function test_func(String)")));
+        assert_eq!(result, Err(format!("Argument error: No function test_func(String)")));
     }
 
     #[test]

--- a/src/operators/scalar/types.rs
+++ b/src/operators/scalar/types.rs
@@ -158,7 +158,7 @@ where
                     if element_type.is_none() {
                         element_type = Some(expr_type.clone())
                     } else if Some(expr_type) != element_type.as_ref() {
-                        return Err(type_error("Array with elements of different type"));
+                        return Err(OptimizerError::argument(format!("Array with elements of different types")));
                     }
                 }
             }

--- a/src/sql/aggregate_tests.yaml
+++ b/src/sql/aggregate_tests.yaml
@@ -112,7 +112,7 @@ ok: |
 query: |
   SELECT sum(a1) as x FROM a GROUP BY a1 HAVING x > 100
 error: |
-  Internal error: Unexpected column: x. Input columns: [(a1, 1), (a2, 2), (a3, 3), (a4, 4)], Outer columns: []
+  Argument error: Unexpected column: x. Input columns: [(a1, 1), (a2, 2), (a3, 3), (a4, 4)], Outer columns: []
 ---
 query: |
   SELECT a1 FROM a HAVING a1 > 100

--- a/src/sql/basic_tests.yaml
+++ b/src/sql/basic_tests.yaml
@@ -47,19 +47,19 @@ ok: |
 query: |
   SELECT a1,b2 FROM A
 error: |
-  Internal error: Unexpected column: b2. Input columns: [(a1, 1), (a2, 2), (a3, 3), (a4, 4)], Outer columns: []
+  Argument error: Unexpected column: b2. Input columns: [(a1, 1), (a2, 2), (a3, 3), (a4, 4)], Outer columns: []
 
 ---
 query: |
   SELECT a.* FROM A as a1
 error: |
-  Internal error: Invalid reference to relation a
+  Argument error: Invalid reference to relation a
 
 ---
 query: |
   SELECT 1 as x, x FROM a
 error: |
-  Internal error: Unexpected column: x. Input columns: [(a1, 1), (a2, 2), (a3, 3), (a4, 4)], Outer columns: []
+  Argument error: Unexpected column: x. Input columns: [(a1, 1), (a2, 2), (a3, 3), (a4, 4)], Outer columns: []
 
 ---
 # wildcard
@@ -82,7 +82,7 @@ queries:
  - SELECT t.* FROM (SELECT * FROM (SELECT * FROM a t JOIN b ON true) t1) t2
  - SELECT t.* FROM (SELECT * FROM (SELECT * FROM a t0 JOIN b ON true) t) t2
 error: |
-  Internal error: Unknown relation t
+  Argument error: Unknown relation t
 
 ---
 # Ordering
@@ -119,7 +119,7 @@ ok: |
 query: |
   SELECT q.b1 FROM (SELECT a1 as x FROM a as t JOIN b as y on b1=a1 ORDER BY x, b1) q
 error: |
-  Internal error: Unexpected column: q.b1. Input columns: [(x, 8)], Outer columns: []
+  Argument error: Unexpected column: q.b1. Input columns: [(x, 8)], Outer columns: []
 
 ---
 # disallow forward references

--- a/src/sql/cte_tests.yaml
+++ b/src/sql/cte_tests.yaml
@@ -173,5 +173,5 @@ query: |
   )
   SELECT a4 FROM a1_vals
 error: |
-  Internal error: Unexpected column: a4. Input columns: [(a1, 1), (a2, 2), (a3, 3)], Outer columns: []
+  Argument error: Unexpected column: a4. Input columns: [(a1, 1), (a2, 2), (a3, 3)], Outer columns: []
 ---

--- a/src/sql/expr_basic_tests.yaml
+++ b/src/sql/expr_basic_tests.yaml
@@ -76,11 +76,11 @@ catalog:
     columns: i:int32, b:bool, s:string
 query: lower(i) FROM test
 error: |
-  Internal error: No function lower(Int32)
+  Argument error: No function lower(Int32)
 ---
 query: lower(123)
 error: |
-  Internal error: No function lower(Int32)
+  Argument error: No function lower(Int32)
 ---
 query: concat('a', 1, true)
 ok: concat([a, 1, true])
@@ -111,9 +111,11 @@ ok: 11 NOT BETWEEN 0 AND 10
 #query: 5 BETWEEN ASYMMETRIC 0 AND 10
 #ok: 5 BETWEEN ASYMMETRIC 0 AND 10
 #---
+# Tuples
 query: (1, true, NOT false, 'abc')
 ok: (1, true, NOT false, abc)
 ---
+# Arrays
 query: |
   ARRAY[1, 2, 3]
 ok: |
@@ -149,11 +151,29 @@ queries:
 error: |
   Argument error: Multidimensional arrays must have array expressions with matching dimensions
 ---
+catalog:
+  - table: test
+    columns: i:int32, b:bool, s:string
+query:
+  ARRAY[i, 1] FROM test
+ok: |
+  [col:1, 1]
+---
+catalog:
+  - table: test
+    columns: i:int32, b:bool, s:string
+query: |
+  ARRAY[i, b] FROM test
+error: |
+  Argument error: Array with elements of different types
+---
+# Array access
 query: |
   ARRAY[[1,2,3], [4,5,6]][1][3]
 ok: |
   [[1, 2, 3], [4, 5, 6]][1][3]
 ---
+# Date/time types
 query: DATE '2000-12-03'
 ok: 2000-12-03
 ---

--- a/src/sql/joins_tests.yaml
+++ b/src/sql/joins_tests.yaml
@@ -75,6 +75,6 @@ query: |
   JOIN b ON a1 = c1
   JOIN c ON c1 = a1
 error: |
-  Internal error: Unexpected column: c1. Input columns: [(a1, 1), (a2, 2), (a3, 3), (a4, 4), (b1, 5), (b2, 6), (b3, 7)], Outer columns: []
+  Argument error: Unexpected column: c1. Input columns: [(a1, 1), (a2, 2), (a3, 3), (a4, 4), (b1, 5), (b2, 6), (b3, 7)], Outer columns: []
 
 ---

--- a/src/sql/subqueries_tests.yaml
+++ b/src/sql/subqueries_tests.yaml
@@ -260,14 +260,14 @@ ok: |
 query: |
   SELECT a1 FROM a, (SELECT a1) tmp;
 error: |
-  Internal error: Unexpected column: a1. Input columns: [], Outer columns: [(a1, 1), (a2, 2), (a3, 3), (a4, 4)]
+  Argument error: Unexpected column: a1. Input columns: [], Outer columns: [(a1, 1), (a2, 2), (a3, 3), (a4, 4)]
 ---
 query: |
   SELECT a1 FROM a JOIN (SELECT b1 FROM b WHERE b1=a1) b ON true
 error: |
-  Internal error: Unexpected column: a1. Input columns: [(b1, 5), (b2, 6), (b3, 7)], Outer columns: []
+  Argument error: Unexpected column: a1. Input columns: [(b1, 5), (b2, 6), (b3, 7)], Outer columns: []
 ---
 query: |
   SELECT a1 FROM a LEFT JOIN b ON b2 = a2 LEFT JOIN (SELECT c1 FROM c WHERE c1=a2) bc ON true;
 error: |
-  Internal error: Unexpected column: a2. Input columns: [(c1, 8), (c2, 9), (c3, 10)], Outer columns: []
+  Argument error: Unexpected column: a2. Input columns: [(c1, 8), (c2, 9), (c3, 10)], Outer columns: []


### PR DESCRIPTION
- when query contains unexpected column.
- when query contains unknown relation.
- when array element types do not match.