### PR TITLE
introduce additional cost per operator (fixes test_streaming_aggregat…

### DIFF
--- a/src/cost/mod.rs
+++ b/src/cost/mod.rs
@@ -10,6 +10,11 @@ pub mod simple;
 //FIXME Wrap into struct to prevent overflows?
 pub type Cost = f64;
 
+/// Additional cost per operator.
+/// This extra cost is added to each an operator by the optimizer so a plan with more operator
+/// has a higher cost than a plan with less operators.
+pub const COST_PER_OPERATOR: f64 = 1f64;
+
 /// Estimates a cost of a physical expression.
 pub trait CostEstimator {
     /// Estimates the cost of the given physical expression excluding the cost of its inputs.


### PR DESCRIPTION
…e_provides_ordering test).

do not optimize physical expression if that expression has already been optimized.
use is_rules_applied only for logical expressions.